### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/lib/CUFTS/Resources/Base/DOI.pm
+++ b/lib/CUFTS/Resources/Base/DOI.pm
@@ -51,7 +51,7 @@ sub build_linkFulltext {
 
 	if ( not_empty_string($request->doi) ) {
 		my $url;
-		$url .= 'http://dx.doi.org/';
+		$url .= 'https://doi.org/';
 		$url .= uri_escape($request->doi, "^A-Za-z0-9\-_.!~*'()\/");
 
 		my $result = new CUFTS::Result($url);


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

I'd simply like to suggest to update the code that generates new DOI links accordingly.

Cheers!